### PR TITLE
README.md: fix typo in pkg.go.dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # clilog
 
-+[![Go Reference](https://pkg.go.dev/badge/github.com/jroimartin/clilog.svg)](https://pkg.go.dev/github.com/jroimartin/clilog)
+[![Go Reference](https://pkg.go.dev/badge/github.com/jroimartin/clilog.svg)](https://pkg.go.dev/github.com/jroimartin/clilog)
 
 Package clilog provides a slog.Handler for command line tools.


### PR DESCRIPTION
Fix typo in README.